### PR TITLE
Readme typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Use this as a reference when you run into unexpected errors in your terminal.
 4. Make sure to stop all processes
 5. Go back to Terminal and run your ruby code again
 
-## Error: Unable to run shotgun & bundle excec not working
-1. Gem uninstall rack
+## Error: Unable to run shotgun & bundle exec not working
+1. In terminal try `Gem uninstall rack`
 2. Follow prompt to remove version of rack that doesn’t work with sinatra
 
 ## Error: Localhost not working


### PR DESCRIPTION
1.  Fixed typo line 6 "Activ**t**ity" to "Activity", although it appears correct in current Readme in VS Code but not online (see screenshot).

2. Fixed typo line 11 "ex**c**ec" to "exec"

3. Added backticks to line 12 "gem uninstall rack" as it is a code command and rest of readme uses this format for commands
<img width="1096" alt="Screen Shot 2020-06-25 at 4 21 35 PM" src="https://user-images.githubusercontent.com/33066436/85805221-92dc1000-b700-11ea-8531-322e22fd0ad5.png">
